### PR TITLE
Add EXPORT to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,11 +232,13 @@ endif()
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
   if(ZLIB_BUILD_SHARED_LIBS)
     install(TARGETS zlib
+        EXPORT zlib
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
   endif()
   if(ZLIB_BUILD_STATIC_LIBS)
     install(TARGETS zlibstatic
+        EXPORT zlib
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" )
   endif()
 endif()


### PR DESCRIPTION
This adds an export set to the install so that it can be installed through dependent libraries that rely on it. This came up in updating pbrt to latest Ptex, where Ptex and zlib are linked statically, but the lack of an export set causes the build to fail on Windows.